### PR TITLE
added bind 9.11

### DIFF
--- a/index.mdwn
+++ b/index.mdwn
@@ -3,7 +3,7 @@
 
 Currently `dnstap` can only encode wire-format DNS messages. It is planned to support additional types of DNS log information.
 
-Server-side `dnstap` support is included in the [Knot DNS](https://www.knot-dns.cz/) authoritative nameserver as of [version 1.5.0](https://lists.nic.cz/pipermail/knot-dns-users/2014-July/000477.html) and in the [Unbound](http://unbound.net/) recursive DNS server as of [version 1.5.0](http://www.unbound.net/pipermail/unbound-users/2014-November/003620.html). It is planned to develop `dnstap` support for additional DNS servers and other kinds of DNS software.
+Server-side `dnstap` support is included in the [Knot DNS](https://www.knot-dns.cz/) authoritative nameserver as of [version 1.5.0](https://lists.nic.cz/pipermail/knot-dns-users/2014-July/000477.html) and in the [Unbound](http://unbound.net/) recursive DNS server as of [version 1.5.0](http://www.unbound.net/pipermail/unbound-users/2014-November/003620.html) and in upcoming [Bind](http://www.isc.org) as of [version 9.11](https://kb.isc.org/article/AA-01409/81/BIND-9.11.0rc1-Release-Notes.html). It is planned to develop `dnstap` support for additional DNS servers and other kinds of DNS software.
 
 A standalone command-line tool for receiving and decoding `dnstap` log messages is also being worked on. Check out [this example output](https://gist.github.com/edmonds/5772879) from the `dnstap` command to get an idea of the kind of information that `dnstap` can encode.
 


### PR DESCRIPTION
bind 9.11 is going to support dnstap see https://kb.isc.org/article/AA-01409/81/BIND-9.11.0rc1-Release-Notes.html
Added support for dnstap, a fast, flexible method for capturing and logging DNS traffic, developed by Robert Edmonds at Farsight Security, Inc., whose assistance is gratefully acknowledged.
